### PR TITLE
Bugfix/verify branch created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0]
+
+### Added
+- **start-work.sh**: Added support for command-line arguments (e.g., `./start-work.sh feature my-task`) to bypass interactive menus for faster usage.
+- **start-work.sh**: Added automatic input sanitization to prevent Git errors by converting spaces to hyphens and forcing lowercase branch names.
+- **start-work.sh**: Added a proactive check to detect if a target branch already exists locally, offering to switch to it safely instead of aborting.
+
+### Fixed
+- **start-work.sh**: Fixed a logic error where the script would incorrectly report "Success" even if the `git checkout` command failed due to invalid characters.
+
 ## [1.1.0]
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@ Stop the repetitive busywork and start every new project with a consistent found
 
 ### Features
 
-### Features
-
 * **Standard Directory Structure**: Creates a clean project layout with `src`, `docs`, and `tests` folders.
 * **Smart Language Setup**: Automatically detects and configures your environment:
     * **Python**: Creates a `.venv`, upgrades pip, and adds a `requirements.txt`.
@@ -71,19 +69,36 @@ The script will then guide you through the setup process, asking for the `.gitig
 
 ### Using the `start-work.sh` Script
 
-The `start-project.sh` script automatically includes a handy `start-work.sh` script (from the [start-work-script repository](https://github.com/KnowOneActual/start-work-script)) in your new project's root directory. This tool helps you quickly start a new task by automating the Git branching process.
+The `start-project.sh` script automatically includes a handy `start-work.sh` script in your new project's root directory. This tool helps you quickly start a new task by automating the Git branching process.
 
-1.  **Make it Executable** (This is done automatically by the main script)
-    ```bash
-    chmod +x start-work.sh
-    ```
-2.  **Run it**
-    When you're ready to start a new feature or fix, run the script from your project's root directory:
-    ```bash
-    ./start-work.sh
-    ```
+It comes with two modes: **Interactive** (menus) and **Fast-Track** (arguments).
 
-It will ask for a branch name, sync your `main` branch with the remote, and then create and switch to the new feature branch for you.
+#### Option 1: Interactive Mode
+
+Run the script without arguments to be guided through a menu:
+
+```bash
+./start-work.sh
+```
+
+  * **Prompts you** for the branch type (Feature, Bugfix, etc.) and name.
+  * **Auto-detects** your main branch to ensure you are syncing with the correct source.
+
+#### Option 2: Fast-Track Mode
+
+Skip the menus by passing the branch type and name directly:
+
+```bash
+# Syntax: ./start-work.sh [type] [name]
+
+./start-work.sh feature new-login-page
+# Result: switches to branch 'feature/new-login-page'
+```
+
+#### Smart Features
+
+  * **Auto-Sanitization**: Don't worry about formatting. If you type "Fix Login Bug", the script automatically converts it to `fix-login-bug`.
+  * **Safety Checks**: The script checks if your workspace is dirty or if the branch already exists before running commands, preventing accidental overwrites.
 
 ### License
 

--- a/start-work.sh
+++ b/start-work.sh
@@ -75,7 +75,14 @@ fi
 
 # --- Step 4: Creating the new branch ---
 echo "3. Creating and switching to: '$BRANCH_NAME'..."
-git checkout -b "$BRANCH_NAME"
 
-echo ""
-echo "✅ You are now on branch '$BRANCH_NAME'."
+# Attempt to create the branch and capture the success/failure
+if git checkout -b "$BRANCH_NAME"; then
+    echo ""
+    echo "✅ You are now on branch '$BRANCH_NAME'."
+else
+    echo ""
+    echo "❌ Failed to create branch '$BRANCH_NAME'."
+    echo "   (Please check for invalid characters or existing branches with similar names)"
+    exit 1
+fi

--- a/start-work.sh
+++ b/start-work.sh
@@ -2,9 +2,14 @@
 
 # --- Git Workflow Starter ---
 # 1. Checks for uncommitted changes.
-# 2. Asks for a branch type and name.
+# 2. Asks for (or accepts) a branch type and name.
 # 3. Syncs the main branch (Auto-detected).
 # 4. Creates and switches to the new branch.
+
+# --- Argument Parsing ---
+# Allow passing arguments directly: ./start-work.sh [type] [name]
+ARG_TYPE=$1
+ARG_NAME=$2
 
 # --- Step 0: Auto-detect Main Branch ---
 # Attempts to find the default branch name (main, master, etc.)
@@ -35,12 +40,25 @@ fi
 echo ""
 
 # --- Step 2: Get the new branch name ---
-echo "Select the type of branch:"
-echo "  1) feature/  (New features)"
-echo "  2) bugfix/   (Bug fixes)"
-echo "  3) hotfix/   (Urgent production fixes)"
-echo "  4) custom    (No prefix)"
-read -p "Choose (1-4): " type_choice
+
+# Logic to handle Branch Type (Argument vs Menu)
+if [ -n "$ARG_TYPE" ]; then
+    # Map text arguments to numbers for the case statement
+    case $ARG_TYPE in
+        feature|feat) type_choice=1 ;;
+        bugfix|fix|bug) type_choice=2 ;;
+        hotfix) type_choice=3 ;;
+        *) type_choice=4 ;; # Default to custom if unknown
+    esac
+    echo "🚀 Fast-track mode: creating '$ARG_TYPE' branch."
+else
+    echo "Select the type of branch:"
+    echo "  1) feature/  (New features)"
+    echo "  2) bugfix/   (Bug fixes)"
+    echo "  3) hotfix/   (Urgent production fixes)"
+    echo "  4) custom    (No prefix)"
+    read -p "Choose (1-4): " type_choice
+fi
 
 case $type_choice in
     1) prefix="feature/" ;;
@@ -49,15 +67,23 @@ case $type_choice in
     *) prefix="" ;;
 esac
 
-echo "Enter the name for your new branch (e.g., add-user-login):"
-read -r RAW_NAME
+# Logic to handle Branch Name (Argument vs Prompt)
+if [ -n "$ARG_NAME" ]; then
+    RAW_NAME="$ARG_NAME"
+else
+    echo "Enter the name for your new branch (e.g., add-user-login):"
+    read -r RAW_NAME
+fi
 
-if [ -z "$RAW_NAME" ]; then
+# Sanitize: lowercase and replace spaces with hyphens
+CLEAN_NAME=$(echo "$RAW_NAME" | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
+
+if [ -z "$CLEAN_NAME" ]; then
     echo "❌ No branch name entered. Aborting."
     exit 1
 fi
 
-BRANCH_NAME="${prefix}${RAW_NAME}"
+BRANCH_NAME="${prefix}${CLEAN_NAME}"
 echo "Target Branch: $BRANCH_NAME"
 echo ""
 
@@ -73,8 +99,23 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# --- Step 4: Creating the new branch ---
-echo "3. Creating and switching to: '$BRANCH_NAME'..."
+# --- Step 4: Creating (or Switching to) the branch ---
+echo "3. Preparing branch: '$BRANCH_NAME'..."
+
+# Check if branch already exists locally
+if git show-ref --verify --quiet "refs/heads/$BRANCH_NAME"; then
+    echo "⚠️  Branch '$BRANCH_NAME' already exists locally."
+    read -p "Switch to it instead? (y/n): " switch_choice
+    if [[ "$switch_choice" =~ ^[Yy]$ ]]; then
+        git checkout "$BRANCH_NAME"
+        echo ""
+        echo "✅ Switched to existing branch '$BRANCH_NAME'."
+        exit 0
+    else
+        echo "❌ Aborting to prevent overwriting work."
+        exit 1
+    fi
+fi
 
 # Attempt to create the branch and capture the success/failure
 if git checkout -b "$BRANCH_NAME"; then


### PR DESCRIPTION
### Added
- **start-work.sh**: Added support for command-line arguments (e.g., `./start-work.sh feature my-task`) to bypass interactive menus for faster usage.
- **start-work.sh**: Added automatic input sanitization to prevent Git errors by converting spaces to hyphens and forcing lowercase branch names.
- **start-work.sh**: Added a proactive check to detect if a target branch already exists locally, offering to switch to it safely instead of aborting.

### Fixed
- **start-work.sh**: Fixed a logic error where the script would incorrectly report "Success" even if the `git checkout` command failed due to invalid characters.

